### PR TITLE
Show enemy block ranges

### DIFF
--- a/core/src/mindustry/graphics/OverlayRenderer.java
+++ b/core/src/mindustry/graphics/OverlayRenderer.java
@@ -122,7 +122,7 @@ public class OverlayRenderer{
             Vec2 vec = Core.input.mouseWorld(input.getMouseX(), input.getMouseY());
             Tile tile = world.ltileWorld(vec.x, vec.y);
 
-            if(tile != null && tile.block() != Blocks.air && tile.getTeam() == player.getTeam()){
+            if(tile != null && tile.block() != Blocks.air){
                 tile.block().drawSelect(tile);
 
                 if(Core.input.keyDown(Binding.rotateplaced) && tile.block().rotate && tile.interactable(player.getTeam())){


### PR DESCRIPTION
I've removed a check which makes the radius for blocks such as turrets and projectors only show on your team. This allows you to see the range of enemy turrets which is useful when building near enemy ripples, etc.

![example turrets](https://user-images.githubusercontent.com/45705145/83505001-8bae5180-a508-11ea-891c-1f1dbd0d91be.gif)

